### PR TITLE
Just return nil when provide a nil as prefix not “nil”

### DIFF
--- a/lib/exometer_statix.ex
+++ b/lib/exometer_statix.ex
@@ -104,6 +104,7 @@ defmodule ExometerStatix do
   defp report(:counter, n, v), do: Client.increment(n, v)
   defp report(:histogram, n, v), do: Client.histogram(n, v)
 
+  defp prefix(nil), do: nil
   defp prefix(v) when is_atom(v), do: Atom.to_string(v)
   defp prefix(v), do: v
 end


### PR DESCRIPTION
I think we just want to return nil when providing nil as prefix and not converting to a string

```elixir
is_atom(nil) # => true
```